### PR TITLE
Add TypeScript compile check workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,18 @@
+name: TypeScript Compile Check
+
+on:
+  pull_request:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run TypeScript compiler
+        run: npx tsc -p tsconfig.json --noEmit


### PR DESCRIPTION
## Summary
- add a workflow triggered on PRs that runs `npm ci`
- check that TypeScript sources compile using `tsc --noEmit`
- update workflow to use Node.js 22

## Testing
- `npm test` *(fails: Missing script)*
- `npm ci` *(fails: cannot reach registry)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*
